### PR TITLE
Potential fix for code scanning alert no. 1: Prototype-polluting assignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\" \"*.{json,md}\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\" \"*.{json,md}\"",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
-    "lint:fix": "eslint --no-warn-ignored \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
+    "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage",

--- a/src/engine/board.ts
+++ b/src/engine/board.ts
@@ -126,7 +126,17 @@ export class Board {
    * @param piece - The piece to place, or null to clear
    */
   public setPieceAt(row: number, col: number, piece: Piece | null): void {
-    if (row < 0 || row > 7 || col < 0 || col > 7) return;
+    if (
+      typeof row !== "number" ||
+      typeof col !== "number" ||
+      row < 0 || row > 7 ||
+      col < 0 || col > 7
+    ) return;
+    // Defensive against prototype pollution (shouldn't be possible, but safe)
+    if (
+      row === "__proto__" || row === "constructor" || row === "prototype" ||
+      col === "__proto__" || col === "constructor" || col === "prototype"
+    ) return;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.board[row]![col] = piece;
   }

--- a/src/engine/board.ts
+++ b/src/engine/board.ts
@@ -127,16 +127,14 @@ export class Board {
    */
   public setPieceAt(row: number, col: number, piece: Piece | null): void {
     if (
-      typeof row !== "number" ||
-      typeof col !== "number" ||
-      row < 0 || row > 7 ||
-      col < 0 || col > 7
-    ) return;
-    // Defensive against prototype pollution (shouldn't be possible, but safe)
-    if (
-      row === "__proto__" || row === "constructor" || row === "prototype" ||
-      col === "__proto__" || col === "constructor" || col === "prototype"
-    ) return;
+      typeof row !== 'number' ||
+      typeof col !== 'number' ||
+      row < 0 ||
+      row > 7 ||
+      col < 0 ||
+      col > 7
+    )
+      return;
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.board[row]![col] = piece;
   }


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/npm-chess/security/code-scanning/1](https://github.com/RumenDamyanov/npm-chess/security/code-scanning/1)

The best way to fix prototype pollution in this context is defensive validation: restrict the indices (`row`, `col`) in `setPieceAt` (and related methods, if needed) so they are explicitly numbers in range and not special object property keys. While the code currently checks value ranges (0–7), add a check that verifies the type (`typeof row === 'number' && typeof col === 'number'`), and THEN the bounds, so that string inputs (like `"__proto__"`) are outright rejected.

The change must be made in `src/engine/board.ts`, specifically within the `setPieceAt(row, col, piece)` method at line 128–132 block. No function signature changes are needed, just a more robust guard clause.  
No new external libraries are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
